### PR TITLE
feat(auth): add social login with github and google providers

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -12,4 +12,14 @@ export const auth = betterAuth({
     emailAndPassword: {
         enabled: true,
     },
+    socialProviders: {
+        github: {
+            clientId: process.env.GITHUB_CLIENT_ID as string,
+            clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
+        },
+        google: {
+            clientId: process.env.GOOGLE_CLIENT_ID as string,
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
+        },
+    },
 });

--- a/src/modules/auth/ui/views/sign-in-view.tsx
+++ b/src/modules/auth/ui/views/sign-in-view.tsx
@@ -139,6 +139,11 @@ const SignInView = () => {
                                         variant={'outline'}
                                         type="button"
                                         className="w-full"
+                                        onClick={() => {
+                                            authClient.signIn.social({
+                                                provider: 'google',
+                                            });
+                                        }}
                                     >
                                         Google
                                     </Button>
@@ -146,6 +151,11 @@ const SignInView = () => {
                                         variant={'outline'}
                                         type="button"
                                         className="w-full"
+                                        onClick={() => {
+                                            authClient.signIn.social({
+                                                provider: 'github',
+                                            });
+                                        }}
                                     >
                                         Github
                                     </Button>

--- a/src/modules/auth/ui/views/sign-up-view.tsx
+++ b/src/modules/auth/ui/views/sign-up-view.tsx
@@ -185,6 +185,11 @@ const SignUpView = () => {
                                         variant={'outline'}
                                         type="button"
                                         className="w-full"
+                                        onClick={() => {
+                                            authClient.signIn.social({
+                                                provider: 'google',
+                                            });
+                                        }}
                                     >
                                         Google
                                     </Button>
@@ -192,6 +197,11 @@ const SignUpView = () => {
                                         variant={'outline'}
                                         type="button"
                                         className="w-full"
+                                        onClick={() => {
+                                            authClient.signIn.social({
+                                                provider: 'github',
+                                            });
+                                        }}
                                     >
                                         Github
                                     </Button>


### PR DESCRIPTION
Add support for GitHub and Google OAuth providers in authentication configuration and implement social login buttons in sign-in/sign-up views. The implementation reads credentials from environment variables and connects the UI buttons to the authentication service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google and GitHub social sign-in options to both the sign-in and sign-up views, allowing users to authenticate using their social accounts.

* **Bug Fixes**
  * Enabled functionality for previously inactive social login buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->