### PR TITLE
feat: meeting action items (roadmap 1.1)

### DIFF
--- a/scripts/stream-webhook.ts
+++ b/scripts/stream-webhook.ts
@@ -1,0 +1,72 @@
+/**
+ * Dev utility: inspect (and optionally fix) the Stream app's webhook config.
+ *
+ *   npx tsx scripts/stream-webhook.ts            # inspect current config
+ *   npx tsx scripts/stream-webhook.ts --fix      # set webhook URL + enable all events
+ *
+ * Set WEBHOOK_URL below or via env to your public tunnel + /api/webhook.
+ */
+import 'dotenv/config';
+import { StreamClient } from '@stream-io/node-sdk';
+
+const client = new StreamClient(
+    process.env.NEXT_PUBLIC_STREAM_VIDEO_API_KEY!,
+    process.env.STREAM_VIDEO_API_SECRET!
+);
+
+const WEBHOOK_URL =
+    process.env.STREAM_WEBHOOK_URL ??
+    'https://improved-humpback-clever.ngrok-free.app/api/webhook';
+
+async function main() {
+    const shouldFix = process.argv.includes('--fix');
+
+    const app = await client.getApp();
+    const a = (app as unknown as { app: Record<string, unknown> }).app ?? app;
+    console.log('=== Webhook-relevant config ===');
+    console.log('legacy webhook_url:', JSON.stringify(a.webhook_url));
+    const hooks = (a.event_hooks as Array<Record<string, unknown>>) ?? [];
+    console.log(`event_hooks: ${hooks.length}`);
+    for (const h of hooks) {
+        const ets = (h.event_types as string[]) ?? [];
+        const callEvents = ets.filter((e) => e.startsWith('call.'));
+        console.log('\n--- hook ---');
+        console.log('  id      :', h.id);
+        console.log('  type    :', h.hook_type);
+        console.log('  enabled :', h.enabled);
+        console.log(
+            '  url     :',
+            h.webhook_url ?? h.webhook_url_v2 ?? h.url ?? h.callback_url ?? '(none)'
+        );
+        console.log('  #events :', ets.length, '| has "*":', ets.includes('*'));
+        console.log(
+            '  call.session_started included:',
+            ets.includes('call.session_started')
+        );
+        console.log('  call.* events:', callEvents.join(', ') || '(none)');
+    }
+
+    if (!shouldFix) {
+        console.log(
+            '\nRun again with --fix to set the webhook URL and enable all events.'
+        );
+        return;
+    }
+
+    console.log(`\n=== Fixing: setting webhook_url -> ${WEBHOOK_URL} ===`);
+    await client.updateApp({
+        webhook_url: WEBHOOK_URL,
+        // Empty/unset event list = send all events (incl. call.session_started).
+        webhook_events: [],
+    });
+    console.log('Updated. Re-fetching to confirm:');
+    const after = await client.getApp();
+    console.log(JSON.stringify(after, null, 2));
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+        console.error('stream-webhook script failed:', err);
+        process.exit(1);
+    });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -108,3 +108,27 @@ export const meetings = pgTable('meetings', {
     createdAt: timestamp('created_at').notNull().defaultNow(),
     updatedAt: timestamp('updated_at').notNull().defaultNow(),
 });
+
+// Structured action items extracted from a meeting transcript by the
+// post-processing job (see src/inngest/function.ts). Users can also add/remove
+// items manually and check them off.
+export const meetingActionItems = pgTable('meeting_action_items', {
+    id: text('id')
+        .primaryKey()
+        .$defaultFn(() => nanoid()),
+    meetingId: text('meeting_id')
+        .notNull()
+        .references(() => meetings.id, {
+            onDelete: 'cascade',
+        }),
+    task: text('task').notNull(),
+    // Free-text so the model can return a name or "Unassigned"; nullable.
+    owner: text('owner'),
+    // Free-text so the model can return a relative date like "next Friday"; nullable.
+    dueDate: text('due_date'),
+    completed: boolean('completed').notNull().default(false),
+    // Distinguishes AI-extracted items from ones the user added by hand.
+    source: text('source').notNull().default('ai'),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+});

--- a/src/inngest/function.ts
+++ b/src/inngest/function.ts
@@ -2,8 +2,8 @@ import JSONL from 'jsonl-parse-stringify';
 import { inngest } from './client';
 import { StreamTranscriptItem } from '@/modules/meeting/types';
 import { db } from '@/db';
-import { agents, meetings, user } from '@/db/schema';
-import { eq, inArray } from 'drizzle-orm';
+import { agents, meetingActionItems, meetings, user } from '@/db/schema';
+import { and, eq, inArray } from 'drizzle-orm';
 import { geminiClient, GEMINI_CHAT_MODEL } from '@/lib/gemini';
 
 const SUMMARIZER_SYSTEM_PROMPT = `You are an expert summarizer. You write readable, concise, simple content. You are given a transcript of a meeting and you need to summarize it.
@@ -25,6 +25,28 @@ const SUMMARIZER_SYSTEM_PROMPT = `You are an expert summarizer. You write readab
     #### Next Section
     - Feature X automatically does Y
     - Mention of integration with Z`.trim();
+
+const ACTION_ITEMS_SYSTEM_PROMPT = `You extract concrete, actionable follow-up tasks from a meeting transcript.
+
+Return ONLY valid JSON matching this exact shape:
+{
+  "actionItems": [
+    { "task": "string — a clear, imperative task", "owner": "string | null — the person responsible if stated, else null", "dueDate": "string | null — a due date or timeframe if mentioned (e.g. 'Friday', 'next sprint'), else null" }
+  ]
+}
+
+Rules:
+- Only include real action items: things someone committed to do or that were explicitly assigned. Do NOT invent tasks.
+- Phrase each task concisely in the imperative ("Send the proposal", not "John will send the proposal").
+- Put the responsible person in "owner" (not in the task text). Use null if no owner was named.
+- Use null for "dueDate" if none was mentioned. Never fabricate a date.
+- If there are no action items, return { "actionItems": [] }.`.trim();
+
+type ExtractedActionItem = {
+    task: string;
+    owner: string | null;
+    dueDate: string | null;
+};
 
 export const meetingsProcessing = inngest.createFunction(
     { id: 'meetings/processing' },
@@ -114,6 +136,66 @@ export const meetingsProcessing = inngest.createFunction(
                     status: 'completed',
                 })
                 .where(eq(meetings.id, event.data.meetingId));
+        });
+
+        const actionItems = await step.run('extract-action-items', async () => {
+            const response = await geminiClient.chat.completions.create({
+                model: GEMINI_CHAT_MODEL,
+                response_format: { type: 'json_object' },
+                messages: [
+                    { role: 'system', content: ACTION_ITEMS_SYSTEM_PROMPT },
+                    {
+                        role: 'user',
+                        content:
+                            'Extract the action items from the following transcript:\n' +
+                            JSON.stringify(transcriptWithSpeaker),
+                    },
+                ],
+            });
+
+            const raw = response.choices[0].message.content ?? '{}';
+
+            try {
+                const parsed = JSON.parse(raw) as {
+                    actionItems?: ExtractedActionItem[];
+                };
+                // Defensive: keep only items with a non-empty task string.
+                return (parsed.actionItems ?? []).filter(
+                    (item) =>
+                        typeof item?.task === 'string' &&
+                        item.task.trim().length > 0
+                );
+            } catch {
+                // Bad JSON shouldn't fail the whole job — just skip extraction.
+                return [] as ExtractedActionItem[];
+            }
+        });
+
+        await step.run('save-action-items', async () => {
+            // Idempotent: clear AI-extracted items before reinserting so a retry
+            // doesn't duplicate them. Manually-added items (source !== 'ai') stay.
+            await db
+                .delete(meetingActionItems)
+                .where(
+                    and(
+                        eq(meetingActionItems.meetingId, event.data.meetingId),
+                        eq(meetingActionItems.source, 'ai')
+                    )
+                );
+
+            if (actionItems.length === 0) {
+                return;
+            }
+
+            await db.insert(meetingActionItems).values(
+                actionItems.map((item) => ({
+                    meetingId: event.data.meetingId as string,
+                    task: item.task.trim(),
+                    owner: item.owner?.trim() || null,
+                    dueDate: item.dueDate?.trim() || null,
+                    source: 'ai',
+                }))
+            );
         });
     }
 );

--- a/src/modules/meeting/server/procedures.ts
+++ b/src/modules/meeting/server/procedures.ts
@@ -1,5 +1,5 @@
 import { db } from '@/db';
-import { agents, meetings, user } from '@/db/schema';
+import { agents, meetingActionItems, meetings, user } from '@/db/schema';
 import {
     createTRPCRouter,
     premiumProcedure,
@@ -8,6 +8,7 @@ import {
 import { z } from 'zod';
 import {
     and,
+    asc,
     count,
     desc,
     eq,
@@ -370,5 +371,143 @@ export const meetingsRouter = createTRPCRouter({
                 total: total.count,
                 totalPages,
             };
+        }),
+
+    getActionItems: protectedProcedure
+        .input(z.object({ meetingId: z.string() }))
+        .query(async ({ input, ctx }) => {
+            // Ownership check: the meeting must belong to the caller.
+            const [meeting] = await db
+                .select({ id: meetings.id })
+                .from(meetings)
+                .where(
+                    and(
+                        eq(meetings.id, input.meetingId),
+                        eq(meetings.userId, ctx.auth.user.id)
+                    )
+                );
+
+            if (!meeting) {
+                throw new TRPCError({
+                    code: 'NOT_FOUND',
+                    message: 'Meeting Not Found',
+                });
+            }
+
+            return db
+                .select()
+                .from(meetingActionItems)
+                .where(eq(meetingActionItems.meetingId, input.meetingId))
+                .orderBy(
+                    asc(meetingActionItems.completed),
+                    asc(meetingActionItems.createdAt)
+                );
+        }),
+
+    addActionItem: protectedProcedure
+        .input(
+            z.object({
+                meetingId: z.string(),
+                task: z.string().min(1, 'Task is required').max(500),
+                owner: z.string().max(120).nullish(),
+                dueDate: z.string().max(120).nullish(),
+            })
+        )
+        .mutation(async ({ input, ctx }) => {
+            const [meeting] = await db
+                .select({ id: meetings.id })
+                .from(meetings)
+                .where(
+                    and(
+                        eq(meetings.id, input.meetingId),
+                        eq(meetings.userId, ctx.auth.user.id)
+                    )
+                );
+
+            if (!meeting) {
+                throw new TRPCError({
+                    code: 'NOT_FOUND',
+                    message: 'Meeting Not Found',
+                });
+            }
+
+            const [created] = await db
+                .insert(meetingActionItems)
+                .values({
+                    meetingId: input.meetingId,
+                    task: input.task.trim(),
+                    owner: input.owner?.trim() || null,
+                    dueDate: input.dueDate?.trim() || null,
+                    source: 'manual',
+                })
+                .returning();
+
+            return created;
+        }),
+
+    toggleActionItem: protectedProcedure
+        .input(z.object({ id: z.string(), completed: z.boolean() }))
+        .mutation(async ({ input, ctx }) => {
+            // Verify the item belongs to a meeting owned by the caller.
+            const [item] = await db
+                .select({ id: meetingActionItems.id })
+                .from(meetingActionItems)
+                .innerJoin(
+                    meetings,
+                    eq(meetingActionItems.meetingId, meetings.id)
+                )
+                .where(
+                    and(
+                        eq(meetingActionItems.id, input.id),
+                        eq(meetings.userId, ctx.auth.user.id)
+                    )
+                );
+
+            if (!item) {
+                throw new TRPCError({
+                    code: 'NOT_FOUND',
+                    message: 'Action item not found',
+                });
+            }
+
+            const [updated] = await db
+                .update(meetingActionItems)
+                .set({ completed: input.completed, updatedAt: new Date() })
+                .where(eq(meetingActionItems.id, input.id))
+                .returning();
+
+            return updated;
+        }),
+
+    removeActionItem: protectedProcedure
+        .input(z.object({ id: z.string() }))
+        .mutation(async ({ input, ctx }) => {
+            const [item] = await db
+                .select({ id: meetingActionItems.id })
+                .from(meetingActionItems)
+                .innerJoin(
+                    meetings,
+                    eq(meetingActionItems.meetingId, meetings.id)
+                )
+                .where(
+                    and(
+                        eq(meetingActionItems.id, input.id),
+                        eq(meetings.userId, ctx.auth.user.id)
+                    )
+                );
+
+            if (!item) {
+                throw new TRPCError({
+                    code: 'NOT_FOUND',
+                    message: 'Action item not found',
+                });
+            }
+
+            const [deleted] = await db
+                .delete(meetingActionItems)
+                .where(eq(meetingActionItems.id, input.id))
+                .returning();
+
+            return deleted;
         }),
 });

--- a/src/modules/meeting/types.ts
+++ b/src/modules/meeting/types.ts
@@ -5,6 +5,8 @@ import type { AppRouter } from '@/trpc/router/_app';
 export type MeetingGetOne = inferRouterOutputs<AppRouter>['meetings']['getOne'];
 export type MeetingGetMany =
     inferRouterOutputs<AppRouter>['meetings']['getMany']['items'];
+export type MeetingActionItem =
+    inferRouterOutputs<AppRouter>['meetings']['getActionItems'][number];
 
 export enum MeetingStatus {
     Upcoming = 'upcoming',

--- a/src/modules/meeting/ui/components/action-items.tsx
+++ b/src/modules/meeting/ui/components/action-items.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTRPC } from '@/trpc/client';
+import {
+    useMutation,
+    useQuery,
+    useQueryClient,
+} from '@tanstack/react-query';
+import { toast } from 'sonner';
+import {
+    CalendarIcon,
+    ListTodoIcon,
+    Loader2Icon,
+    PlusIcon,
+    Trash2Icon,
+    UserIcon,
+} from 'lucide-react';
+
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+interface ActionItemsProps {
+    meetingId: string;
+}
+
+const ActionItems = ({ meetingId }: ActionItemsProps) => {
+    const trpc = useTRPC();
+    const queryClient = useQueryClient();
+    const [newTask, setNewTask] = useState('');
+
+    const queryOptions = trpc.meetings.getActionItems.queryOptions({
+        meetingId,
+    });
+    const { data: actionItems = [], isLoading } = useQuery(queryOptions);
+
+    const invalidate = () =>
+        queryClient.invalidateQueries({ queryKey: queryOptions.queryKey });
+
+    const toggle = useMutation(
+        trpc.meetings.toggleActionItem.mutationOptions({
+            onSuccess: () => invalidate(),
+            onError: () => toast.error('Failed to update action item'),
+        })
+    );
+
+    const add = useMutation(
+        trpc.meetings.addActionItem.mutationOptions({
+            onSuccess: () => {
+                setNewTask('');
+                invalidate();
+            },
+            onError: () => toast.error('Failed to add action item'),
+        })
+    );
+
+    const remove = useMutation(
+        trpc.meetings.removeActionItem.mutationOptions({
+            onSuccess: () => invalidate(),
+            onError: () => toast.error('Failed to remove action item'),
+        })
+    );
+
+    const handleAdd = (e: React.FormEvent) => {
+        e.preventDefault();
+        const task = newTask.trim();
+        if (!task) return;
+        add.mutate({ meetingId, task });
+    };
+
+    const completedCount = actionItems.filter((i) => i.completed).length;
+
+    return (
+        <div className="bg-white rounded-lg border px-4 py-5 flex flex-col gap-y-4 w-full">
+            <div className="flex items-center justify-between">
+                <div className="flex items-center gap-x-2">
+                    <ListTodoIcon className="size-4" />
+                    <p className="text-sm font-medium">Action Items</p>
+                </div>
+                {actionItems.length > 0 && (
+                    <Badge variant="outline">
+                        {completedCount}/{actionItems.length} done
+                    </Badge>
+                )}
+            </div>
+
+            {isLoading ? (
+                <div className="flex items-center justify-center py-8 text-muted-foreground">
+                    <Loader2Icon className="size-5 animate-spin" />
+                </div>
+            ) : actionItems.length === 0 ? (
+                <p className="text-sm text-muted-foreground py-2">
+                    No action items were found for this meeting. Add one below.
+                </p>
+            ) : (
+                <div className="flex flex-col gap-y-2">
+                    {actionItems.map((item) => (
+                        <div
+                            key={item.id}
+                            className="group flex items-start gap-x-3 rounded-md border p-3 hover:bg-muted/50"
+                        >
+                            <Checkbox
+                                className="mt-0.5"
+                                checked={item.completed}
+                                disabled={toggle.isPending}
+                                onCheckedChange={(checked) =>
+                                    toggle.mutate({
+                                        id: item.id,
+                                        completed: checked === true,
+                                    })
+                                }
+                            />
+                            <div className="flex flex-col gap-y-1 flex-1">
+                                <p
+                                    className={cn(
+                                        'text-sm',
+                                        item.completed &&
+                                            'line-through text-muted-foreground'
+                                    )}
+                                >
+                                    {item.task}
+                                </p>
+                                <div className="flex flex-wrap items-center gap-2">
+                                    {item.owner && (
+                                        <Badge
+                                            variant="secondary"
+                                            className="gap-x-1 [&>svg]:size-3"
+                                        >
+                                            <UserIcon />
+                                            {item.owner}
+                                        </Badge>
+                                    )}
+                                    {item.dueDate && (
+                                        <Badge
+                                            variant="outline"
+                                            className="gap-x-1 [&>svg]:size-3"
+                                        >
+                                            <CalendarIcon />
+                                            {item.dueDate}
+                                        </Badge>
+                                    )}
+                                </div>
+                            </div>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                className="size-7 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive"
+                                disabled={remove.isPending}
+                                onClick={() => remove.mutate({ id: item.id })}
+                            >
+                                <Trash2Icon className="size-4" />
+                            </Button>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            <form onSubmit={handleAdd} className="flex items-center gap-x-2">
+                <Input
+                    placeholder="Add an action item…"
+                    value={newTask}
+                    onChange={(e) => setNewTask(e.target.value)}
+                    className="h-9"
+                />
+                <Button
+                    type="submit"
+                    size="sm"
+                    disabled={add.isPending || newTask.trim().length === 0}
+                >
+                    {add.isPending ? (
+                        <Loader2Icon className="size-4 animate-spin" />
+                    ) : (
+                        <PlusIcon className="size-4" />
+                    )}
+                    Add
+                </Button>
+            </form>
+        </div>
+    );
+};
+
+export default ActionItems;

--- a/src/modules/meeting/ui/components/completed-state.tsx
+++ b/src/modules/meeting/ui/components/completed-state.tsx
@@ -8,6 +8,7 @@ import {
     ClockFadingIcon,
     FileTextIcon,
     FileVideoIcon,
+    ListTodoIcon,
     SparklesIcon,
 } from 'lucide-react';
 import Link from 'next/link';
@@ -17,6 +18,7 @@ import { Badge } from '@/components/ui/badge';
 import { formatDuration } from '@/lib/utils';
 import Transcript from './transcript';
 import ChatProvider from './chat-provider';
+import ActionItems from './action-items';
 interface CompletedStateProps {
     data: MeetingGetOne;
 }
@@ -34,6 +36,13 @@ const CompletedState = ({ data }: CompletedStateProps) => {
                             >
                                 <BookOpenTextIcon />
                                 Summary
+                            </TabsTrigger>
+                            <TabsTrigger
+                                value="action-items"
+                                className="text-muted-foreground rounded-none bg-background data-[state=active]:shadow-none border-b-2 border-transparent data-[state=active]:border-b-primary data-[state=active]:text-accent-foreground h-full hover:text-accent-foreground"
+                            >
+                                <ListTodoIcon />
+                                Action Items
                             </TabsTrigger>
                             <TabsTrigger
                                 value="transcript"
@@ -187,6 +196,9 @@ const CompletedState = ({ data }: CompletedStateProps) => {
                             </div>
                         </div>
                     </div>
+                </TabsContent>
+                <TabsContent value="action-items">
+                    <ActionItems meetingId={data.id} />
                 </TabsContent>
                 <TabsContent value="transcript">
                     <Transcript meetingId={data.id} />


### PR DESCRIPTION
## Summary
Implements **Roadmap 1.1 — Action items extraction**, the flagged `first` item in the build order.

After a meeting is transcribed, the Inngest post-processing job now runs a second, structured Gemini step that extracts concrete action items (`task` / `owner` / `dueDate`) into a new table. The completed meeting page gains an **Action Items** tab — a checklist users can tick off, add to manually, and delete from.

## Changes
- **DB** (`src/db/schema.ts`): new `meeting_action_items` table (FK to `meetings`, cascade delete; `source` distinguishes `ai` vs `manual`).
- **Pipeline** (`src/inngest/function.ts`): `extract-action-items` (Gemini `json_object` output, defensive parsing) + `save-action-items` steps. Idempotent — a retry clears only AI items and keeps manually-added ones.
- **API** (`src/modules/meeting/server/procedures.ts`): `getActionItems`, `addActionItem`, `toggleActionItem`, `removeActionItem` — all ownership-checked through the parent meeting.
- **UI**: `action-items.tsx` checklist (toggle / add / remove, owner & due-date badges, completed count) wired into a new tab in `completed-state.tsx`.

## Notes
- Schema already `db:push`ed to the dev database.
- `npx tsc --noEmit` and `next lint` both pass clean.
- Real meetings auto-populate from the transcript; the manual **Add** works on any completed meeting immediately. (Existing seeded meetings have no transcript, so they start empty until items are added.)

## Test plan
- [ ] Complete a real meeting → Action Items tab populates from the transcript
- [ ] Toggle an item → persists; completed count updates
- [ ] Add a manual item → appears; survives pipeline re-run
- [ ] Delete an item → removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)