### PR TITLE
feat: meeting decisions log (roadmap 1.2)

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -132,3 +132,25 @@ export const meetingActionItems = pgTable('meeting_action_items', {
     createdAt: timestamp('created_at').notNull().defaultNow(),
     updatedAt: timestamp('updated_at').notNull().defaultNow(),
 });
+
+// Key decisions captured from a meeting transcript by the post-processing job
+// (see src/inngest/function.ts). Users can also add/remove decisions manually.
+// Unlike action items these aren't "completable" — they're a record of what
+// was decided.
+export const meetingDecisions = pgTable('meeting_decisions', {
+    id: text('id')
+        .primaryKey()
+        .$defaultFn(() => nanoid()),
+    meetingId: text('meeting_id')
+        .notNull()
+        .references(() => meetings.id, {
+            onDelete: 'cascade',
+        }),
+    decision: text('decision').notNull(),
+    // Free-text rationale / background for the decision; nullable.
+    context: text('context'),
+    // Distinguishes AI-extracted decisions from ones the user added by hand.
+    source: text('source').notNull().default('ai'),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+});

--- a/src/inngest/function.ts
+++ b/src/inngest/function.ts
@@ -2,7 +2,13 @@ import JSONL from 'jsonl-parse-stringify';
 import { inngest } from './client';
 import { StreamTranscriptItem } from '@/modules/meeting/types';
 import { db } from '@/db';
-import { agents, meetingActionItems, meetings, user } from '@/db/schema';
+import {
+    agents,
+    meetingActionItems,
+    meetingDecisions,
+    meetings,
+    user,
+} from '@/db/schema';
 import { and, eq, inArray } from 'drizzle-orm';
 import { geminiClient, GEMINI_CHAT_MODEL } from '@/lib/gemini';
 
@@ -46,6 +52,27 @@ type ExtractedActionItem = {
     task: string;
     owner: string | null;
     dueDate: string | null;
+};
+
+const DECISIONS_SYSTEM_PROMPT = `You extract the key decisions made during a meeting from its transcript.
+
+Return ONLY valid JSON matching this exact shape:
+{
+  "decisions": [
+    { "decision": "string — a clear statement of what was decided", "context": "string | null — brief rationale or background for the decision if stated, else null" }
+  ]
+}
+
+Rules:
+- Only include real decisions: choices the group actually committed to or agreed on. Do NOT invent decisions.
+- State each decision concisely as a settled outcome ("Ship weekly releases", not "We should maybe release weekly").
+- Put any supporting rationale or background in "context". Use null if none was given.
+- Do NOT include action items or tasks here — only decisions.
+- If there are no decisions, return { "decisions": [] }.`.trim();
+
+type ExtractedDecision = {
+    decision: string;
+    context: string | null;
 };
 
 export const meetingsProcessing = inngest.createFunction(
@@ -193,6 +220,66 @@ export const meetingsProcessing = inngest.createFunction(
                     task: item.task.trim(),
                     owner: item.owner?.trim() || null,
                     dueDate: item.dueDate?.trim() || null,
+                    source: 'ai',
+                }))
+            );
+        });
+
+        const decisions = await step.run('extract-decisions', async () => {
+            const response = await geminiClient.chat.completions.create({
+                model: GEMINI_CHAT_MODEL,
+                response_format: { type: 'json_object' },
+                messages: [
+                    { role: 'system', content: DECISIONS_SYSTEM_PROMPT },
+                    {
+                        role: 'user',
+                        content:
+                            'Extract the decisions from the following transcript:\n' +
+                            JSON.stringify(transcriptWithSpeaker),
+                    },
+                ],
+            });
+
+            const raw = response.choices[0].message.content ?? '{}';
+
+            try {
+                const parsed = JSON.parse(raw) as {
+                    decisions?: ExtractedDecision[];
+                };
+                // Defensive: keep only entries with a non-empty decision string.
+                return (parsed.decisions ?? []).filter(
+                    (item) =>
+                        typeof item?.decision === 'string' &&
+                        item.decision.trim().length > 0
+                );
+            } catch {
+                // Bad JSON shouldn't fail the whole job — just skip extraction.
+                return [] as ExtractedDecision[];
+            }
+        });
+
+        await step.run('save-decisions', async () => {
+            // Idempotent: clear AI-extracted decisions before reinserting so a
+            // retry doesn't duplicate them. Manually-added ones (source !== 'ai')
+            // stay.
+            await db
+                .delete(meetingDecisions)
+                .where(
+                    and(
+                        eq(meetingDecisions.meetingId, event.data.meetingId),
+                        eq(meetingDecisions.source, 'ai')
+                    )
+                );
+
+            if (decisions.length === 0) {
+                return;
+            }
+
+            await db.insert(meetingDecisions).values(
+                decisions.map((item) => ({
+                    meetingId: event.data.meetingId as string,
+                    decision: item.decision.trim(),
+                    context: item.context?.trim() || null,
                     source: 'ai',
                 }))
             );

--- a/src/modules/meeting/server/procedures.ts
+++ b/src/modules/meeting/server/procedures.ts
@@ -1,5 +1,11 @@
 import { db } from '@/db';
-import { agents, meetingActionItems, meetings, user } from '@/db/schema';
+import {
+    agents,
+    meetingActionItems,
+    meetingDecisions,
+    meetings,
+    user,
+} from '@/db/schema';
 import {
     createTRPCRouter,
     premiumProcedure,
@@ -506,6 +512,103 @@ export const meetingsRouter = createTRPCRouter({
             const [deleted] = await db
                 .delete(meetingActionItems)
                 .where(eq(meetingActionItems.id, input.id))
+                .returning();
+
+            return deleted;
+        }),
+
+    getDecisions: protectedProcedure
+        .input(z.object({ meetingId: z.string() }))
+        .query(async ({ input, ctx }) => {
+            // Ownership check: the meeting must belong to the caller.
+            const [meeting] = await db
+                .select({ id: meetings.id })
+                .from(meetings)
+                .where(
+                    and(
+                        eq(meetings.id, input.meetingId),
+                        eq(meetings.userId, ctx.auth.user.id)
+                    )
+                );
+
+            if (!meeting) {
+                throw new TRPCError({
+                    code: 'NOT_FOUND',
+                    message: 'Meeting Not Found',
+                });
+            }
+
+            return db
+                .select()
+                .from(meetingDecisions)
+                .where(eq(meetingDecisions.meetingId, input.meetingId))
+                .orderBy(asc(meetingDecisions.createdAt));
+        }),
+
+    addDecision: protectedProcedure
+        .input(
+            z.object({
+                meetingId: z.string(),
+                decision: z.string().min(1, 'Decision is required').max(500),
+                context: z.string().max(1000).nullish(),
+            })
+        )
+        .mutation(async ({ input, ctx }) => {
+            const [meeting] = await db
+                .select({ id: meetings.id })
+                .from(meetings)
+                .where(
+                    and(
+                        eq(meetings.id, input.meetingId),
+                        eq(meetings.userId, ctx.auth.user.id)
+                    )
+                );
+
+            if (!meeting) {
+                throw new TRPCError({
+                    code: 'NOT_FOUND',
+                    message: 'Meeting Not Found',
+                });
+            }
+
+            const [created] = await db
+                .insert(meetingDecisions)
+                .values({
+                    meetingId: input.meetingId,
+                    decision: input.decision.trim(),
+                    context: input.context?.trim() || null,
+                    source: 'manual',
+                })
+                .returning();
+
+            return created;
+        }),
+
+    removeDecision: protectedProcedure
+        .input(z.object({ id: z.string() }))
+        .mutation(async ({ input, ctx }) => {
+            // Verify the decision belongs to a meeting owned by the caller.
+            const [item] = await db
+                .select({ id: meetingDecisions.id })
+                .from(meetingDecisions)
+                .innerJoin(meetings, eq(meetingDecisions.meetingId, meetings.id))
+                .where(
+                    and(
+                        eq(meetingDecisions.id, input.id),
+                        eq(meetings.userId, ctx.auth.user.id)
+                    )
+                );
+
+            if (!item) {
+                throw new TRPCError({
+                    code: 'NOT_FOUND',
+                    message: 'Decision not found',
+                });
+            }
+
+            const [deleted] = await db
+                .delete(meetingDecisions)
+                .where(eq(meetingDecisions.id, input.id))
                 .returning();
 
             return deleted;

--- a/src/modules/meeting/types.ts
+++ b/src/modules/meeting/types.ts
@@ -7,6 +7,8 @@ export type MeetingGetMany =
     inferRouterOutputs<AppRouter>['meetings']['getMany']['items'];
 export type MeetingActionItem =
     inferRouterOutputs<AppRouter>['meetings']['getActionItems'][number];
+export type MeetingDecision =
+    inferRouterOutputs<AppRouter>['meetings']['getDecisions'][number];
 
 export enum MeetingStatus {
     Upcoming = 'upcoming',

--- a/src/modules/meeting/ui/components/completed-state.tsx
+++ b/src/modules/meeting/ui/components/completed-state.tsx
@@ -8,6 +8,7 @@ import {
     ClockFadingIcon,
     FileTextIcon,
     FileVideoIcon,
+    GavelIcon,
     ListTodoIcon,
     SparklesIcon,
 } from 'lucide-react';
@@ -19,6 +20,7 @@ import { formatDuration } from '@/lib/utils';
 import Transcript from './transcript';
 import ChatProvider from './chat-provider';
 import ActionItems from './action-items';
+import Decisions from './decisions';
 interface CompletedStateProps {
     data: MeetingGetOne;
 }
@@ -43,6 +45,13 @@ const CompletedState = ({ data }: CompletedStateProps) => {
                             >
                                 <ListTodoIcon />
                                 Action Items
+                            </TabsTrigger>
+                            <TabsTrigger
+                                value="decisions"
+                                className="text-muted-foreground rounded-none bg-background data-[state=active]:shadow-none border-b-2 border-transparent data-[state=active]:border-b-primary data-[state=active]:text-accent-foreground h-full hover:text-accent-foreground"
+                            >
+                                <GavelIcon />
+                                Decisions
                             </TabsTrigger>
                             <TabsTrigger
                                 value="transcript"
@@ -199,6 +208,9 @@ const CompletedState = ({ data }: CompletedStateProps) => {
                 </TabsContent>
                 <TabsContent value="action-items">
                     <ActionItems meetingId={data.id} />
+                </TabsContent>
+                <TabsContent value="decisions">
+                    <Decisions meetingId={data.id} />
                 </TabsContent>
                 <TabsContent value="transcript">
                     <Transcript meetingId={data.id} />

--- a/src/modules/meeting/ui/components/decisions.tsx
+++ b/src/modules/meeting/ui/components/decisions.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTRPC } from '@/trpc/client';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { GavelIcon, Loader2Icon, PlusIcon, Trash2Icon } from 'lucide-react';
+
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+
+interface DecisionsProps {
+    meetingId: string;
+}
+
+const Decisions = ({ meetingId }: DecisionsProps) => {
+    const trpc = useTRPC();
+    const queryClient = useQueryClient();
+    const [newDecision, setNewDecision] = useState('');
+
+    const queryOptions = trpc.meetings.getDecisions.queryOptions({
+        meetingId,
+    });
+    const { data: decisions = [], isLoading } = useQuery(queryOptions);
+
+    const invalidate = () =>
+        queryClient.invalidateQueries({ queryKey: queryOptions.queryKey });
+
+    const add = useMutation(
+        trpc.meetings.addDecision.mutationOptions({
+            onSuccess: () => {
+                setNewDecision('');
+                invalidate();
+            },
+            onError: () => toast.error('Failed to add decision'),
+        })
+    );
+
+    const remove = useMutation(
+        trpc.meetings.removeDecision.mutationOptions({
+            onSuccess: () => invalidate(),
+            onError: () => toast.error('Failed to remove decision'),
+        })
+    );
+
+    const handleAdd = (e: React.FormEvent) => {
+        e.preventDefault();
+        const decision = newDecision.trim();
+        if (!decision) return;
+        add.mutate({ meetingId, decision });
+    };
+
+    return (
+        <div className="bg-white rounded-lg border px-4 py-5 flex flex-col gap-y-4 w-full">
+            <div className="flex items-center justify-between">
+                <div className="flex items-center gap-x-2">
+                    <GavelIcon className="size-4" />
+                    <p className="text-sm font-medium">Decisions</p>
+                </div>
+                {decisions.length > 0 && (
+                    <Badge variant="outline">
+                        {decisions.length}{' '}
+                        {decisions.length === 1 ? 'decision' : 'decisions'}
+                    </Badge>
+                )}
+            </div>
+
+            {isLoading ? (
+                <div className="flex items-center justify-center py-8 text-muted-foreground">
+                    <Loader2Icon className="size-5 animate-spin" />
+                </div>
+            ) : decisions.length === 0 ? (
+                <p className="text-sm text-muted-foreground py-2">
+                    No decisions were captured for this meeting. Add one below.
+                </p>
+            ) : (
+                <div className="flex flex-col gap-y-2">
+                    {decisions.map((item) => (
+                        <div
+                            key={item.id}
+                            className="group flex items-start gap-x-3 rounded-md border p-3 hover:bg-muted/50"
+                        >
+                            <div className="flex flex-col gap-y-1 flex-1">
+                                <p className="text-sm font-medium">
+                                    {item.decision}
+                                </p>
+                                {item.context && (
+                                    <p className="text-sm text-muted-foreground">
+                                        {item.context}
+                                    </p>
+                                )}
+                            </div>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                className="size-7 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive"
+                                disabled={remove.isPending}
+                                onClick={() => remove.mutate({ id: item.id })}
+                            >
+                                <Trash2Icon className="size-4" />
+                            </Button>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            <form onSubmit={handleAdd} className="flex items-center gap-x-2">
+                <Input
+                    placeholder="Add a decision…"
+                    value={newDecision}
+                    onChange={(e) => setNewDecision(e.target.value)}
+                    className="h-9"
+                />
+                <Button
+                    type="submit"
+                    size="sm"
+                    disabled={add.isPending || newDecision.trim().length === 0}
+                >
+                    {add.isPending ? (
+                        <Loader2Icon className="size-4 animate-spin" />
+                    ) : (
+                        <PlusIcon className="size-4" />
+                    )}
+                    Add
+                </Button>
+            </form>
+        </div>
+    );
+};
+
+export default Decisions;


### PR DESCRIPTION
## Roadmap 1.2 — Decisions log

Extracts the key decisions made during a meeting from its transcript and surfaces them on the completed-meeting page, alongside action items (1.1). Mirrors the 1.1 pipeline end to end.

### Changes
- **DB:** new `meeting_decisions` table (`decision`, nullable `context`, `source`), FK→`meetings` with cascade.
- **Inngest:** `extract-decisions` (Gemini JSON-mode; decisions-only, no fabrication) + idempotent `save-decisions` (clears `source='ai'`, preserves manual entries).
- **tRPC:** `getDecisions`, `addDecision`, `removeDecision`, each with a per-meeting ownership check.
- **UI:** new **Decisions** tab on the completed meeting page — list with context sub-text, manual add, hover-delete.
- **Types:** `MeetingDecision`.

### Notes
- No `completed` toggle — a decision is a record, not a task (hence no `toggle` procedure).
- Dropped the roadmap's `timestamp` field, matching how 1.1 dropped `sourceTimestamp` (model-emitted transcript timestamps are unreliable). Easy to add later.
- **Requires a migration:** `npm run db:push` (already applied to the dev DB locally).

### Test
- Open any completed meeting → **Decisions** tab; manual add/remove works immediately.
- Full AI extraction populates when a meeting runs through the `meetings/processing` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)